### PR TITLE
minimal requirement to use CGI.escapeHTML

### DIFF
--- a/lib/csv-diff-report/html.rb
+++ b/lib/csv-diff-report/html.rb
@@ -1,4 +1,9 @@
-require 'cgi/escape'
+if RUBY_VERSION >= "2.3.0"
+    require "cgi/escape"
+else
+    require "cgi/util"
+end
+
 begin
     require 'lcs-diff'
 rescue LoadError

--- a/lib/csv-diff-report/html.rb
+++ b/lib/csv-diff-report/html.rb
@@ -1,4 +1,4 @@
-require 'cgi'
+require 'cgi/escape'
 begin
     require 'lcs-diff'
 rescue LoadError


### PR DESCRIPTION
We need to require only cgi/escape to use CGI.escapeHTML.

This change save memory usage about 265 KB and load time about ten milliseconds.

```rb
require "objspace"

GC.start
before = ObjectSpace.memsize_of_all
require "cgi"
after = ObjectSpace.memsize_of_all
puts "about %d KB" % ((after - before).fdiv(1024).round)
# => 269 KB
```

```rb
require "objspace"

GC.start
before = ObjectSpace.memsize_of_all
require "cgi/escape"
after = ObjectSpace.memsize_of_all
puts "about %d KB" % ((after - before).fdiv(1024).round)
# => 4 KB
```

(Ruby 2.7.0)

